### PR TITLE
Docs: adds info about dashboards as code

### DIFF
--- a/docs/references/content-as-code.mdx
+++ b/docs/references/content-as-code.mdx
@@ -40,13 +40,13 @@ You can use the chart's SLUG, UUID, or the URL to the saved chart to select the 
 
 ### Use `lightdash download -d` or `lightdash download --dashboards` to select specific dashboards
 
-For example, if I only wanted to download a specific dashboard as code, I would run the command:
+This will download the dashboard and all of the charts in the dashboard as code. For example, if I only wanted to download a specific dashboard as code, I would run the command:
 
 ```bash
 lightdash download -d https://app.lightdash.cloud/the-url-to-my-dashboard
 ```
 
-You can use the dashboard's SLUG, UUID, or the URL to the dashboard to select the dashboard.
+You can use the dashboard's SLUG, UUID, or the URL to the dashboard to select the dashboard. 
 
 #### To select multiple charts or dashboards, add a space between the items
 

--- a/docs/references/lightdash-cli.mdx
+++ b/docs/references/lightdash-cli.mdx
@@ -420,7 +420,7 @@ You can make changes to the code and upload these changes back to your Lightdash
 - `--charts` or `-c`
   - select specific charts as code to download from your project. Use the chart SLUG, UUID or URL to specify the chart.
 - `--dashboards` or `-d` 
-  - select specific dashboards as code to download from your project. Use the dashboard SLUG, UUID or URL to specify the dashboard.
+  - select specific dashboards as code to download from your project. This will also download all charts in the dashboard as code. Use the dashboard SLUG, UUID or URL to specify the dashboard.
 
 **Examples:**
 


### PR DESCRIPTION
Adds information about how all charts are downloaded in a dashboard when you download a dashboard as code. 