### PR TITLE
docs: adds custom formatting to docs

### DIFF
--- a/docs/references/dimensions.mdx
+++ b/docs/references/dimensions.mdx
@@ -213,6 +213,7 @@ Example format expressions:
 | Raw Value   | Formatted value | Format expression  |
 | ----------- | --------------- | ------------------ | 
 | 100000.00   | 100,00.00 km    | '#,##0.00" km"'    | 
+| 12345232    | 12345232        | '0'                |
 | 56.7856     | 57              | '#,##0'            |
 | 15430.75436 | $15,430.75      | '[$]#,##0.00'      | 
 | 15430.75436 | $15K            | '[$]#,##0,"K"'     | 
@@ -257,7 +258,7 @@ These are the options:
 | eur     | '[€]#,##0.00'                  | Adds the `€` symbol to your number value                                            | 10         | €10.00          |
 | jpy     | '[¥]#,##0.00'                  | Adds the `¥` symbol to your number value                                            | 10         | ¥10             |
 | percent | '#,##0.00%'                    | Adds the `%` symbol and multiplies your value by 100                                | 0.1        | %10             |
-| id      | No custom format expression    | Removes commas and spaces from number or string types so that they appear like IDs. | 12,389,572 | 12389572        |
+| id      | '0'                            | Removes commas and spaces from number or string types so that they appear like IDs. | 12389572   | 12389572        |
 
 #### Compact (legacy)
 

--- a/docs/references/dimensions.mdx
+++ b/docs/references/dimensions.mdx
@@ -55,8 +55,7 @@ models:
             description: 'My custom description' # you can override the description you'll see in Lightdash here
             sql: 'IF(${TABLE}.revenue_gbp_total_est = NULL, 0, ${registered_user_email})' # custom SQL applied to the column from dbt used to define the dimension
             hidden: false
-            round: 2
-            format: '"£"#,##0.00' # GBP rounded to two decimal points
+            format: '[£]#,##0.00' # GBP rounded to two decimal points
             groups: ['finance']
       - name: forecast_date
         description: 'Date of the forecasting.'
@@ -101,7 +100,7 @@ All the properties you can customize:
 | sql                                         | No       | string                                                                                                                                            | Custom SQL applied to the column used to define the dimension.                                                                                                                                                                                             |
 | [time_intervals](#time-intervals)           | No       | `'default'` or `OFF` or an array[] containing elements of [date](#date-options), [numeric](#numeric-options) or [string](#string-options) options | `'default'` (or not setting the `time_intervals` property) will be converted into `['DAY', 'WEEK', 'MONTH', 'YEAR']` for dates and `['RAW', 'DAY', 'WEEK', 'MONTH', 'YEAR']` for timestamps; if you want no time intervals set `'OFF'`.                    |
 | hidden                                      | No       | boolean                                                                                                                                           | If set to `true`, the dimension is hidden from Lightdash. By default, this is set to `false` if you don't include this property.                                                                                                                           |
-| [format](#format)                           | No       | string                                                                                                                                            | This option will format the output value on the result table and CSV export. Currently supports one of the following: `['km', 'mi', 'usd', 'gbp', 'eur', 'percent', 'id']`                                                                                 |
+| [format](#format)                           | No       | string                                                                                                                                            | This option will format the output value on the results table and CSV export. Supports spreadsheet-style formatting (e.g. #,##0.00). Use [this website](https://customformats.com/) to help build your custom format.`                                                                                 |
 | [groups](#groups)                           | No       | string or string[]                                                                                                                                | If you set this property, the dimension will be grouped in the sidebar with other dimensions with the same group label.                                                                                                                                    |
 | [urls](#urls)                               | No       | Array of { url, label }                                                                                                                           | Adding urls to a dimension allows your users to click dimension values in the UI and take actions, like opening an external tool with a url, or open at a website. You can use liquid templates to customise the link based on the value of the dimension. |
 | [required_attributes](#required-attributes) | No       | Object with { user_attribute, value }                                                                                                             | Limits access to users with those attributes                                                                                                                                                                                                               |
@@ -195,16 +194,18 @@ You can use the `format` parameter to have your dimensions show in a particular 
 To help you build your format expression, we recommend using https://customformats.com/.
 
 ```yaml
-metrics:
-  total_us_revenue:
-    type: sum
-    description: 'Total revenue in USD, with two decimal places, compacted to thousands'
-    format: '$#,##0.00," K"' # 505,430 will appear as '$505.43 K'
-  percent_of_total_global_revenue:
-    type: number
-    description: 'Percent of total global revenue coming from US revenue.'
-    sql: ${total_us_revenue} / ${total_global_revenue}
-    format: '0.00%' # 0.67895243 will appear as '67.89%
+- name: us_revenue
+  meta:
+    dimension:
+      type: number
+      description: 'Revenue in USD, with two decimal places, compacted to thousands'
+      format: '$#,##0.00," K"' # 505,430 will appear as '$505.43 K'
+    additional_dimensions:
+      percent_of_global_revenue:
+        type: number
+        description: 'Percent of total global revenue coming from US revenue.'
+        sql: ${us_revenue} / ${global_revenue}
+        format: '0.00%' # 0.67895243 will appear as '67.89%
 ```
 
 <details>
@@ -235,16 +236,16 @@ models:
 
 These are the options:
 
-| Option  | Description                                                                         | Raw value  | Displayed value |
-| ------- | ----------------------------------------------------------------------------------- | ---------- | --------------- |
-| km      | Adds the suffix `km` to your value                                                  | 10         | 10 km           |
-| mi      | Adds the suffix `mile` to your value                                                | 10         | 10 mi           |
-| usd     | Adds the `$` symbol to your number value                                            | 10         | $10.00          |
-| gbp     | Adds the `£` symbol to your number value                                            | 10         | £10.00          |
-| eur     | Adds the `€` symbol to your number value                                            | 10         | €10.00          |
-| jpy     | Adds the `¥` symbol to your number value                                            | 10         | ¥10             |
-| percent | Adds the `%` symbol and multiplies your value by 100                                | 0.1        | %10             |
-| id      | Removes commas and spaces from number or string types so that they appear like IDs. | 12,389,572 | 12389572        |
+| Option  | Equivalent format expression   | Description                                                                         | Raw value  | Displayed value |
+| ------- | ------------------------------ | ----------------------------------------------------------------------------------- | ---------- | --------------- |
+| km      | '#,##0.00" km"'                | Adds the suffix `km` to your value                                                  | 10         | 10 km           |
+| mi      | '#,##0.00" mi"'                | Adds the suffix `mile` to your value                                                | 10         | 10 mi           |
+| usd     | '[$]#,##0.00'                  | Adds the `$` symbol to your number value                                            | 10         | $10.00          |
+| gbp     | '[£]#,##0.00'                  | Adds the `£` symbol to your number value                                            | 10         | £10.00          |
+| eur     | '[€]#,##0.00'                  | Adds the `€` symbol to your number value                                            | 10         | €10.00          |
+| jpy     | '[¥]#,##0.00'                  | Adds the `¥` symbol to your number value                                            | 10         | ¥10             |
+| percent | '#,##0.00%'                    | Adds the `%` symbol and multiplies your value by 100                                | 0.1        | %10             |
+| id      | No custom format expression    | Removes commas and spaces from number or string types so that they appear like IDs. | 12,389,572 | 12389572        |
 
 #### Compact (legacy)
 
@@ -261,12 +262,12 @@ You can compact values in your YAML. For example, if I wanted all of my revenue 
 	          compact: thousands # You can also use 'K'
 ```
 
-| Value     | Alias              | Example output |
-| --------- | ------------------ | -------------- |
-| thousands | "K" and "thousand" | 1K             |
-| millions  | "M" and "million"  | 1M             |
-| billions  | "B" and "billion"  | 1B             |
-| trillions | "T" and "trillion" | 1T             |
+| Value     | Alias              | Equivalent format expression            | Example output |
+| --------- | ------------------ | --------------------------------------- | -------------- |
+| thousands | "K" and "thousand" | '$#,##0," K"' or '$#,##0.00," K"'       | 1K             |
+| millions  | "M" and "million"  | '$#,##0,," M"' or '$#,##0.00,," M"'     | 1M             |
+| billions  | "B" and "billion"  | '$#,##0,,," B"' or '$#,##0.00,,," B"'   | 1B             |
+| trillions | "T" and "trillion" | '$#,##0,,,," T"' or '$#,##0.00,,,," T"' | 1T             |
 
 #### Round (legacy)
 
@@ -280,7 +281,7 @@ You can round values to appear with a certain number of decimal points.
 	    - name: revenue
 	      meta:
 	        dimension:
-	          round: 0
+	          round: 0 # equivalent format expression: '#,##0.0'
 ```
 
 </details>

--- a/docs/references/dimensions.mdx
+++ b/docs/references/dimensions.mdx
@@ -55,7 +55,7 @@ models:
             description: 'My custom description' # you can override the description you'll see in Lightdash here
             sql: 'IF(${TABLE}.revenue_gbp_total_est = NULL, 0, ${registered_user_email})' # custom SQL applied to the column from dbt used to define the dimension
             hidden: false
-            format: '[£]#,##0.00' # GBP rounded to two decimal points
+            format: '[$£]#,##0.00' # GBP rounded to two decimal points
             groups: ['finance']
       - name: forecast_date
         description: 'Date of the forecasting.'
@@ -80,7 +80,7 @@ models:
               label: 'Day of Week (number)'
               sql: 'day_of_week(${date})'
             day_of_week_day:
-              type: string
+              type: date
               label: 'Day of Week (day)'
               sql: ${date}
               format: 'dddd'
@@ -254,9 +254,9 @@ These are the options:
 | km      | '#,##0.00" km"'                | Adds the suffix `km` to your value                                                  | 10         | 10 km           |
 | mi      | '#,##0.00" mi"'                | Adds the suffix `mile` to your value                                                | 10         | 10 mi           |
 | usd     | '[$]#,##0.00'                  | Adds the `$` symbol to your number value                                            | 10         | $10.00          |
-| gbp     | '[£]#,##0.00'                  | Adds the `£` symbol to your number value                                            | 10         | £10.00          |
-| eur     | '[€]#,##0.00'                  | Adds the `€` symbol to your number value                                            | 10         | €10.00          |
-| jpy     | '[¥]#,##0.00'                  | Adds the `¥` symbol to your number value                                            | 10         | ¥10             |
+| gbp     | '[$£]#,##0.00'                  | Adds the `£` symbol to your number value                                            | 10         | £10.00          |
+| eur     | '[$€]#,##0.00'                  | Adds the `€` symbol to your number value                                            | 10         | €10.00          |
+| jpy     | '[$¥]#,##0.00'                  | Adds the `¥` symbol to your number value                                            | 10         | ¥10             |
 | percent | '#,##0.00%'                    | Adds the `%` symbol and multiplies your value by 100                                | 0.1        | %10             |
 | id      | '0'                            | Removes commas and spaces from number or string types so that they appear like IDs. | 12389572   | 12389572        |
 

--- a/docs/references/dimensions.mdx
+++ b/docs/references/dimensions.mdx
@@ -208,6 +208,18 @@ To help you build your format expression, we recommend using https://customforma
         format: '0.00%' # 0.67895243 will appear as '67.89%
 ```
 
+Example format expressions:
+
+| Raw Value   | Formatted value | Format expression  |
+| ----------- | --------------- | ------------------ | 
+| 100000.00   | 100,00.00 km    | '#,##0.00" km"'    | 
+| 56.7856     | 57              | '#,##0'            |
+| 15430.75436 | $15,430.75      | '[$]#,##0.00'      | 
+| 15430.75436 | $15K            | '[$]#,##0,"K"'     | 
+| 15430.75436 | $15.43K         | '[$]#,##0.00,"K"'  | 
+| 13334567    | $13.33M         | '[$]#,##0.00,,"M"' |
+| 0.6758      | 67.58%          | '#,##0.00%'        | 
+
 <details>
   <summary>(Legacy) format, round, and compact options</summary>
 
@@ -264,10 +276,10 @@ You can compact values in your YAML. For example, if I wanted all of my revenue 
 
 | Value     | Alias              | Equivalent format expression            | Example output |
 | --------- | ------------------ | --------------------------------------- | -------------- |
-| thousands | "K" and "thousand" | '$#,##0," K"' or '$#,##0.00," K"'       | 1K             |
-| millions  | "M" and "million"  | '$#,##0,," M"' or '$#,##0.00,," M"'     | 1M             |
-| billions  | "B" and "billion"  | '$#,##0,,," B"' or '$#,##0.00,,," B"'   | 1B             |
-| trillions | "T" and "trillion" | '$#,##0,,,," T"' or '$#,##0.00,,,," T"' | 1T             |
+| thousands | "K" and "thousand" | '#,##0," K"' or '#,##0.00," K"'       | 1K             |
+| millions  | "M" and "million"  | '#,##0,," M"' or '#,##0.00,," M"'     | 1M             |
+| billions  | "B" and "billion"  | '#,##0,,," B"' or '#,##0.00,,," B"'   | 1B             |
+| trillions | "T" and "trillion" | '#,##0,,,," T"' or '#,##0.00,,,," T"' | 1T             |
 
 #### Round (legacy)
 

--- a/docs/references/dimensions.mdx
+++ b/docs/references/dimensions.mdx
@@ -208,7 +208,7 @@ metrics:
 ```
 
 <details>
-  <summary><b>Legacy `format`, `compact`, and `round` options</b></summary>
+  <summary>(Legacy) format, round, and compact options</summary>
 
 Spreadsheet-style format expressions are the recommended way of adding formatting to your metrics in Lightdash. There are legacy formatting options, listed below, which are less flexible than the spreadsheet-style formatting. 
 
@@ -218,7 +218,7 @@ If you use both legacy and spreadsheet-style formatting options for a single dim
 
 :::
 
-### Format (legacy)
+#### Format (legacy)
 
 ```yaml
 version: 2
@@ -246,7 +246,7 @@ These are the options:
 | percent | Adds the `%` symbol and multiplies your value by 100                                | 0.1        | %10             |
 | id      | Removes commas and spaces from number or string types so that they appear like IDs. | 12,389,572 | 12389572        |
 
-### Compact (legacy)
+#### Compact (legacy)
 
 You can compact values in your YAML. For example, if I wanted all of my revenue values to be shown in thousands (e.g. `1,500` appears as `1.50K`), then I would write something like this in my .yml:
 
@@ -268,7 +268,7 @@ You can compact values in your YAML. For example, if I wanted all of my revenue 
 | billions  | "B" and "billion"  | 1B             |
 | trillions | "T" and "trillion" | 1T             |
 
-### Round (legacy)
+#### Round (legacy)
 
 You can round values to appear with a certain number of decimal points.
 

--- a/docs/references/dimensions.mdx
+++ b/docs/references/dimensions.mdx
@@ -50,13 +50,13 @@ models:
         description: 'Total estimated revenue in GBP based on forecasting done by the finance team.'
         meta:
           dimension:
-            type: string
+            type: number
             label: 'Total revenue' # this is the label you'll see in Lightdash
             description: 'My custom description' # you can override the description you'll see in Lightdash here
             sql: 'IF(${TABLE}.revenue_gbp_total_est = NULL, 0, ${registered_user_email})' # custom SQL applied to the column from dbt used to define the dimension
             hidden: false
             round: 2
-            format: 'gbp'
+            format: '"£"#,##0.00' # GBP rounded to two decimal points
             groups: ['finance']
       - name: forecast_date
         description: 'Date of the forecasting.'
@@ -76,11 +76,16 @@ models:
           dimension:
             type: date
           additional_dimensions:
-            dimension_name_one:
+            day_of_week_num:
               type: number
-              label: 'Day of Week'
+              label: 'Day of Week (number)'
               sql: 'day_of_week(${date})'
-            dimension_name_two:
+            day_of_week_day:
+              type: string
+              label: 'Day of Week (day)'
+              sql: ${date}
+              format: 'dddd'
+            is_weekday_or_weekend:
               type: boolean
               label: 'Weekday or Weekend'
               sql: "case when day_of_week(${date}) < 5 then 'weekday' else 'weekend' end"
@@ -96,9 +101,7 @@ All the properties you can customize:
 | sql                                         | No       | string                                                                                                                                            | Custom SQL applied to the column used to define the dimension.                                                                                                                                                                                             |
 | [time_intervals](#time-intervals)           | No       | `'default'` or `OFF` or an array[] containing elements of [date](#date-options), [numeric](#numeric-options) or [string](#string-options) options | `'default'` (or not setting the `time_intervals` property) will be converted into `['DAY', 'WEEK', 'MONTH', 'YEAR']` for dates and `['RAW', 'DAY', 'WEEK', 'MONTH', 'YEAR']` for timestamps; if you want no time intervals set `'OFF'`.                    |
 | hidden                                      | No       | boolean                                                                                                                                           | If set to `true`, the dimension is hidden from Lightdash. By default, this is set to `false` if you don't include this property.                                                                                                                           |
-| round                                       | No       | number                                                                                                                                            | Rounds a number to a specified number of digits                                                                                                                                                                                                            |
 | [format](#format)                           | No       | string                                                                                                                                            | This option will format the output value on the result table and CSV export. Currently supports one of the following: `['km', 'mi', 'usd', 'gbp', 'eur', 'percent', 'id']`                                                                                 |
-| [compact](#compact-values)                  | No       | string                                                                                                                                            | This option will compact the number value (e.g. 1,500 to 1.50K). Currently supports one of the following: `['thousands', 'millions', 'billions', 'trillions']`                                                                                             |
 | [groups](#groups)                           | No       | string or string[]                                                                                                                                | If you set this property, the dimension will be grouped in the sidebar with other dimensions with the same group label.                                                                                                                                    |
 | [urls](#urls)                               | No       | Array of { url, label }                                                                                                                           | Adding urls to a dimension allows your users to click dimension values in the UI and take actions, like opening an external tool with a url, or open at a website. You can use liquid templates to customise the link based on the value of the dimension. |
 | [required_attributes](#required-attributes) | No       | Object with { user_attribute, value }                                                                                                             | Limits access to users with those attributes                                                                                                                                                                                                               |
@@ -185,7 +188,65 @@ and it will stay on multiple lines
 
 You can also use dbt docs blocks in descriptions, [more on that here](/guides/cli/how-to-auto-generate-schema-files#using-doc-blocks-to-build-better-yml-files).
 
-## Compact values
+## Format
+
+You can use the `format` parameter to have your dimensions show in a particular format in Lightdash. Lightdash supports spreadsheet-style format expressions for all dimension types.
+
+To help you build your format expression, we recommend using https://customformats.com/.
+
+```yaml
+metrics:
+  total_us_revenue:
+    type: sum
+    description: 'Total revenue in USD, with two decimal places, compacted to thousands'
+    format: '$#,##0.00," K"' # 505,430 will appear as '$505.43 K'
+  percent_of_total_global_revenue:
+    type: number
+    description: 'Percent of total global revenue coming from US revenue.'
+    sql: ${total_us_revenue} / ${total_global_revenue}
+    format: '0.00%' # 0.67895243 will appear as '67.89%
+```
+
+<details>
+  <summary><b>Legacy `format`, `compact`, and `round` options</b></summary>
+
+Spreadsheet-style format expressions are the recommended way of adding formatting to your metrics in Lightdash. There are legacy formatting options, listed below, which are less flexible than the spreadsheet-style formatting. 
+
+:::info
+
+If you use both legacy and spreadsheet-style formatting options for a single dimension, Lightdash will ignore the legacy `format`, `compact`, and `round` options and only apply the spreadsheet-style formatting expression.
+
+:::
+
+### Format (legacy)
+
+```yaml
+version: 2
+
+models:
+  - name: sales_stats
+    columns:
+      - name: revenue
+        description: 'Total estimated revenue in GBP based on forecasting done by the finance team.'
+        meta:
+          dimension:
+            format: 'gbp'
+```
+
+These are the options:
+
+| Option  | Description                                                                         | Raw value  | Displayed value |
+| ------- | ----------------------------------------------------------------------------------- | ---------- | --------------- |
+| km      | Adds the suffix `km` to your value                                                  | 10         | 10 km           |
+| mi      | Adds the suffix `mile` to your value                                                | 10         | 10 mi           |
+| usd     | Adds the `$` symbol to your number value                                            | 10         | $10.00          |
+| gbp     | Adds the `£` symbol to your number value                                            | 10         | £10.00          |
+| eur     | Adds the `€` symbol to your number value                                            | 10         | €10.00          |
+| jpy     | Adds the `¥` symbol to your number value                                            | 10         | ¥10             |
+| percent | Adds the `%` symbol and multiplies your value by 100                                | 0.1        | %10             |
+| id      | Removes commas and spaces from number or string types so that they appear like IDs. | 12,389,572 | 12389572        |
+
+### Compact (legacy)
 
 You can compact values in your YAML. For example, if I wanted all of my revenue values to be shown in thousands (e.g. `1,500` appears as `1.50K`), then I would write something like this in my .yml:
 
@@ -197,7 +258,7 @@ You can compact values in your YAML. For example, if I wanted all of my revenue 
 	    - name: revenue
 	      meta:
 	        dimension:
-	            compact: thousands # You can also use 'K'
+	          compact: thousands # You can also use 'K'
 ```
 
 | Value     | Alias              | Example output |
@@ -206,6 +267,23 @@ You can compact values in your YAML. For example, if I wanted all of my revenue 
 | millions  | "M" and "million"  | 1M             |
 | billions  | "B" and "billion"  | 1B             |
 | trillions | "T" and "trillion" | 1T             |
+
+### Round (legacy)
+
+You can round values to appear with a certain number of decimal points.
+
+```yaml
+	version: 2
+	models:
+	- name: sales
+	  columns:
+	    - name: revenue
+	      meta:
+	        dimension:
+	          round: 0
+```
+
+</details>
 
 ## Time intervals
 
@@ -221,6 +299,12 @@ For example, here we have the timestamp dimension `created` defined in our dbt p
 Lightdash breaks this out into the default intervals automatically. So, this is how `created` appears in our Lightdash project:
 
 ![screenshot-default-intervals](assets/screenshot-default-intervals.png)
+
+:::info
+
+[Formatting](#format) added to a date or timestamp dimension will be applied to all of the time intervals for that dimension. If you want to apply different formats for different time intervals, we recommend creating [additional dimensions](#additional-dimensions) for time intervals where you want to customize the format.
+
+:::
 
 ### By default, the time intervals we use are:
 
@@ -294,35 +378,6 @@ You can see all of the interval options for date and timestamp fields below.
 | DAY_OF_WEEK_NAME | Day of the week | String | Monday          |
 | MONTH_NAME       | Month name      | String | March           |
 | QUARTER_NAME     | Quarter name    | String | Q3              |
-
-## Format
-
-You can use the `format` parameter to have your dimensions show in a particular format in Lightdash.
-
-```yaml
-- name: revenue
-  description: 'Timestamp when the user was created.'
-  meta:
-    dimension:
-      format: 'usd'
-    metrics:
-      total_revenue:
-        type: sum
-        format: 'usd'
-```
-
-These are the options:
-
-| Option  | Description                                                                         | Raw value  | Displayed value |
-| ------- | ----------------------------------------------------------------------------------- | ---------- | --------------- |
-| km      | Adds the suffix `km` to your value                                                  | 10         | 10 km           |
-| mi      | Adds the suffix `mile` to your value                                                | 10         | 10 mi           |
-| usd     | Adds the `$` symbol to your number value                                            | 10         | $10.00          |
-| gbp     | Adds the `£` symbol to your number value                                            | 10         | £10.00          |
-| eur     | Adds the `€` symbol to your number value                                            | 10         | €10.00          |
-| jpy     | Adds the `¥` symbol to your number value                                            | 10         | ¥10             |
-| percent | Adds the `%` symbol and multiplies your value by 100                                | 0.1        | %10             |
-| id      | Removes commas and spaces from number or string types so that they appear like IDs. | 12,389,572 | 12389572        |
 
 ## Groups
 

--- a/docs/references/metrics.mdx
+++ b/docs/references/metrics.mdx
@@ -397,6 +397,18 @@ metrics:
     format: '0.00%' # 0.67895243 will appear as '67.89%
 ```
 
+Example format expressions:
+
+| Raw Value   | Formatted value | Format expression  |
+| ----------- | --------------- | ------------------ | 
+| 100000.00   | 100,00.00 km    | '#,##0.00" km"'    | 
+| 56.7856     | 57              | '#,##0'            |
+| 15430.75436 | $15,430.75      | '[$]#,##0.00'      | 
+| 15430.75436 | $15K            | '[$]#,##0,"K"'     | 
+| 15430.75436 | $15.43K         | '[$]#,##0.00,"K"'  | 
+| 13334567    | $13.33M         | '[$]#,##0.00,,"M"' |
+| 0.6758      | 67.58%          | '#,##0.00%'        | 
+
 <details>
   <summary>(Legacy) format, compact, and round options</summary>
 
@@ -458,10 +470,10 @@ You can compact values in your YAML. For example, if I wanted all of my revenue 
 
 | Value     | Alias              | Equivalent format expression            | Example output |
 | --------- | ------------------ | --------------------------------------- | -------------- |
-| thousands | "K" and "thousand" | '$#,##0," K"' or '$#,##0.00," K"'       | 1K             |
-| millions  | "M" and "million"  | '$#,##0,," M"' or '$#,##0.00,," M"'     | 1M             |
-| billions  | "B" and "billion"  | '$#,##0,,," B"' or '$#,##0.00,,," B"'   | 1B             |
-| trillions | "T" and "trillion" | '$#,##0,,,," T"' or '$#,##0.00,,,," T"' | 1T             |
+| thousands | "K" and "thousand" | '#,##0," K"' or '#,##0.00," K"'       | 1K             |
+| millions  | "M" and "million"  | '#,##0,," M"' or '#,##0.00,," M"'     | 1M             |
+| billions  | "B" and "billion"  | '#,##0,,," B"' or '#,##0.00,,," B"'   | 1B             |
+| trillions | "T" and "trillion" | '#,##0,,,," T"' or '#,##0.00,,,," T"' | 1T             |
 
 #### Round (legacy)
 

--- a/docs/references/metrics.mdx
+++ b/docs/references/metrics.mdx
@@ -398,7 +398,7 @@ metrics:
 ```
 
 <details>
-  <summary>(Legacy) format, compact, and round options</b></summary>
+  <summary>(Legacy) format, compact, and round options</summary>
 
 Spreadsheet-style format expressions are the recommended way of adding formatting to your metrics in Lightdash. There are legacy formatting options, listed below, which are less flexible than the spreadsheet-style formatting. 
 

--- a/docs/references/metrics.mdx
+++ b/docs/references/metrics.mdx
@@ -402,6 +402,7 @@ Example format expressions:
 | Raw Value   | Formatted value | Format expression  |
 | ----------- | --------------- | ------------------ | 
 | 100000.00   | 100,00.00 km    | '#,##0.00" km"'    | 
+| 12345232    | 12345232        | '0'                |
 | 56.7856     | 57              | '#,##0'            |
 | 15430.75436 | $15,430.75      | '[$]#,##0.00'      | 
 | 15430.75436 | $15K            | '[$]#,##0,"K"'     | 
@@ -449,7 +450,7 @@ These are the options:
 | eur     | '[€]#,##0.00'                  | Adds the `€` symbol to your number value                                            | 10         | €10.00          |
 | jpy     | '[¥]#,##0.00'                  | Adds the `¥` symbol to your number value                                            | 10         | ¥10             |
 | percent | '#,##0.00%'                    | Adds the `%` symbol and multiplies your value by 100                                | 0.1        | %10             |
-| id      | No custom format expression    | Removes commas and spaces from number or string types so that they appear like IDs. | 12,389,572 | 12389572        |
+| id      | '0'                            | Removes commas and spaces from number or string types so that they appear like IDs. | 12389572   | 12389572        |
 
 #### Compact (legacy)
 

--- a/docs/references/metrics.mdx
+++ b/docs/references/metrics.mdx
@@ -398,7 +398,7 @@ metrics:
 ```
 
 <details>
-  <summary><b>Legacy `format`, `compact`, and `round` options</b></summary>
+  <summary>(Legacy) format, compact, and round options</b></summary>
 
 Spreadsheet-style format expressions are the recommended way of adding formatting to your metrics in Lightdash. There are legacy formatting options, listed below, which are less flexible than the spreadsheet-style formatting. 
 
@@ -408,7 +408,7 @@ If you use both legacy and spreadsheet-style formatting options for a single met
 
 :::
 
-### Format (legacy)
+#### Format (legacy)
 
 ```yaml
 version: 2
@@ -439,7 +439,7 @@ These are the options:
 | percent | Adds the `%` symbol and multiplies your value by 100                                | 0.1        | %10             |
 | id      | Removes commas and spaces from number or string types so that they appear like IDs. | 12,389,572 | 12389572        |
 
-### Compact (legacy)
+#### Compact (legacy)
 
 You can compact values in your YAML. For example, if I wanted all of my revenue values to be shown in thousands (e.g. `1,500` appears as `1.50K`), then I would write something like this in my .yml:
 
@@ -463,7 +463,7 @@ You can compact values in your YAML. For example, if I wanted all of my revenue 
 | billions  | "B" and "billion"  | 1B             |
 | trillions | "T" and "trillion" | 1T             |
 
-### Round (legacy)
+#### Round (legacy)
 
 You can round values to appear with a certain number of decimal points.
 

--- a/docs/references/metrics.mdx
+++ b/docs/references/metrics.mdx
@@ -95,8 +95,7 @@ models:
               sql: 'IF(${revenue} IS NULL, 10, ${revenue})'
               groups: ['product_details', 'item_details'] # this would add the metric to a nested group: `product details` --> `item details`
               hidden: false
-              round: 0
-              format: 'gbp'
+              format: '"£"#,##0.00' # GBP rounded to two decimal points
               show_underlying_values:
                 - revenue
                 - forecast_date
@@ -111,12 +110,10 @@ Here are all of the properties you can customize:
 | --------------------------------------------------- | -------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | label                                               | No       | string                         | Custom label. This is what you'll see in Lightdash instead of the metric name.                                                                                                                                                                       |
 | [type](#metric-types)                               | Yes      | metric type                    | Metrics must be one of the supported types.                                                                                                                                                                                                          |
-| [description](#adding-your-own-metric-descriptions) | No       | string                         | Description of the metric that appears in Lightdash. A default description is created by Lightdash if this isn't included                                                                                                                            |
-| [sql](#using-custom-sql-in-aggregate-metrics)       | No       | string                         | Custom SQL used to define the metric.                                                                                                                                                                                                                |
+| [description](#description)                         | No       | string                         | Description of the metric that appears in Lightdash. A default description is created by Lightdash if this isn't included                                                                                                                            |
+| [sql](#custom-sql-in-aggregate-metrics)             | No       | string                         | Custom SQL used to define the metric.                                                                                                                                                                                                                |
 | hidden                                              | No       | boolean                        | If set to `true`, the metric is hidden from Lightdash. By default, this is set to `false` if you don't include this property.                                                                                                                        |
-| round                                               | No       | number                         | Rounds a number to a specified number of digits                                                                                                                                                                                                      |
-| [format](#format)                                   | No       | string                         | This option will format the output value on the result table and CSV export. Currently supports one of the following: `['km', 'mi', 'usd', 'gbp', 'eur', 'percent', 'id']`                                                                           |
-| [compact](#compact-values)                          | No       | string                         | This option will compact the number value (e.g. 1,500 to 1.50K). Currently supports one of the following: `['thousands', 'millions', 'billions', 'trillions']`                                                                                       |
+| [format](#format)                                   | No       | string                         | This option will format the output value on the results table and CSV export. Currently supports one of the following: `['km', 'mi', 'usd', 'gbp', 'eur', 'percent', 'id']`                                                                           |
 | [groups](#groups)                                   | No       | string or string[]             | If you set this property, the metric will be grouped in the sidebar with other metrics with the same group label.                                                                                                                                    |
 | [urls](./dimensions.mdx#urls)                       | No       | Array of { url, label }        | Adding urls to a metric allows your users to click metric values in the UI and take actions, like opening an external tool with a url, or open at a website. You can use liquid templates to customise the link based on the value of the dimension. |
 | [show_underlying_values](#show-underlying-values)   | No       | Array of dimension names       | You can limit which dimensions are shown for a field when a user clicks `View underlying data`. The list must only include dimension names from the base model or from any joined models.                                                            |
@@ -370,7 +367,7 @@ columns:
           sql: 'GROUP_CONCAT(${TABLE}.product_name)'
 ```
 
-## Adding your own metric descriptions
+## Description
 
 We add default descriptions to all of the metrics you include in your model. But, you can override these using the description parameter when you define your metric.
 
@@ -381,7 +378,111 @@ metrics:
     description: 'Total number of user IDs. NOTE: this is NOT counting unique user IDs'
 ```
 
-## Using custom SQL in aggregate metrics
+## Format
+
+You can use the `format` parameter to have your metrics show in a particular format in Lightdash. Lightdash supports spreadsheet-style format expressions for all metric types.
+
+To help you build your format expression, we recommend using https://customformats.com/.
+
+```yaml
+metrics:
+  total_us_revenue:
+    type: sum
+    description: 'Total revenue in USD, with two decimal places, compacted to thousands'
+    format: '$#,##0.00," K"' # 505,430 will appear as '$505.43 K'
+  percent_of_total_global_revenue:
+    type: number
+    description: 'Percent of total global revenue coming from US revenue.'
+    sql: ${total_us_revenue} / ${total_global_revenue}
+    format: '0.00%' # 0.67895243 will appear as '67.89%
+```
+
+<details>
+  <summary><b>Legacy `format`, `compact`, and `round` options</b></summary>
+
+Spreadsheet-style format expressions are the recommended way of adding formatting to your metrics in Lightdash. There are legacy formatting options, listed below, which are less flexible than the spreadsheet-style formatting. 
+
+:::info
+
+If you use both legacy and spreadsheet-style formatting options for a single metric, Lightdash will ignore the legacy `format`, `compact`, and `round` options and only apply the spreadsheet-style formatting expression.
+
+:::
+
+### Format (legacy)
+
+```yaml
+version: 2
+
+models:
+  - name: sales_stats
+    columns:
+      - name: revenue
+        description: 'Total estimated revenue in GBP based on forecasting done by the finance team.'
+        meta:
+          metrics:
+            total_revenue:
+              label: 'Total revenue GBP'
+              type: SUM
+              format: 'gbp'
+```
+
+These are the options:
+
+| Option  | Description                                                                         | Raw value  | Displayed value |
+| ------- | ----------------------------------------------------------------------------------- | ---------- | --------------- |
+| km      | Adds the suffix `km` to your value                                                  | 10         | 10 km           |
+| mi      | Adds the suffix `mile` to your value                                                | 10         | 10 mi           |
+| usd     | Adds the `$` symbol to your number value                                            | 10         | $10.00          |
+| gbp     | Adds the `£` symbol to your number value                                            | 10         | £10.00          |
+| eur     | Adds the `€` symbol to your number value                                            | 10         | €10.00          |
+| jpy     | Adds the `¥` symbol to your number value                                            | 10         | ¥10             |
+| percent | Adds the `%` symbol and multiplies your value by 100                                | 0.1        | %10             |
+| id      | Removes commas and spaces from number or string types so that they appear like IDs. | 12,389,572 | 12389572        |
+
+### Compact (legacy)
+
+You can compact values in your YAML. For example, if I wanted all of my revenue values to be shown in thousands (e.g. `1,500` appears as `1.50K`), then I would write something like this in my .yml:
+
+```yaml
+	version: 2
+	models:
+	- name: sales
+	  columns:
+	    - name: revenue
+	      meta:
+	        metrics:
+            total_revenue:
+              type: sum
+	            compact: thousands # You can also use 'K'
+```
+
+| Value     | Alias              | Example output |
+| --------- | ------------------ | -------------- |
+| thousands | "K" and "thousand" | 1K             |
+| millions  | "M" and "million"  | 1M             |
+| billions  | "B" and "billion"  | 1B             |
+| trillions | "T" and "trillion" | 1T             |
+
+### Round (legacy)
+
+You can round values to appear with a certain number of decimal points.
+
+```yaml
+	version: 2
+	models:
+	- name: sales
+	  columns:
+	    - name: revenue
+	      meta:
+          metrics:
+            total_revenue:
+              type: sum
+              round: 0
+```
+
+</details>
+
+## Custom SQL in aggregate metrics
 
 You can include custom SQL in your metric definition to build more advanced metrics using the sql parameter.
 Inside the sql parameter, you can reference any other dimension from the given model and any joined models. You **can’t reference other metrics.**
@@ -399,7 +500,7 @@ metrics:
     sql: 'IF(${subscriptions.is_active}, ${user_id}, NULL)'
 ```
 
-## Using custom SQL in non-aggregate metrics
+## Custom SQL in non-aggregate metrics
 
 In non-aggregate metrics, you can reference any other metric from the given model and any joined models. You **can’t reference other dimensions.**
 
@@ -458,28 +559,6 @@ models:
 The list of fields must be made of dimension names (no metrics) from the base table or from any joined tables. To reference a field from a joined table, you just need to prefix the dimension name with the joined table name, like this: `my_joined_table_name.my_dimension`.
 
 The order that the fields are listed in `show_underlying_values` is the order that they'll appear in on the `view underlying data` table.
-
-## Compact values
-
-You can compact values in your YAML. For example, if I wanted all of my revenue values to be shown in thousands (e.g. `1,500` appears as `1.50K`), then I would write something like this in my .yml:
-
-```yaml
-	version: 2
-	models:
-	- name: sales
-	  columns:
-	    - name: revenue
-	      meta:
-	        dimension:
-	            compact: thousands # You can also use 'K'
-```
-
-| Value     | Alias              | Example output |
-| --------- | ------------------ | -------------- |
-| thousands | "K" and "thousand" | 1K             |
-| millions  | "M" and "million"  | 1M             |
-| billions  | "B" and "billion"  | 1B             |
-| trillions | "T" and "trillion" | 1T             |
 
 ## Groups
 
@@ -687,36 +766,3 @@ models:
               filters:
                 - status: 'shipped'
 ```
-
-## Format
-
-You can use the `format` parameter to have your metrics show in a particular format in Lightdash.
-
-```yaml
-version: 2
-
-models:
-  - name: sales_stats
-    columns:
-      - name: revenue
-        description: 'Total estimated revenue in GBP based on forecasting done by the finance team.'
-        meta:
-          metrics:
-            total_revenue:
-              label: 'Total revenue GBP'
-              type: SUM
-              format: 'gbp'
-```
-
-These are the options:
-
-| Option  | Description                                                                         | Raw value  | Displayed value |
-| ------- | ----------------------------------------------------------------------------------- | ---------- | --------------- |
-| km      | Adds the suffix `km` to your value                                                  | 10         | 10 km           |
-| mi      | Adds the suffix `mile` to your value                                                | 10         | 10 mi           |
-| usd     | Adds the `$` symbol to your number value                                            | 10         | $10.00          |
-| gbp     | Adds the `£` symbol to your number value                                            | 10         | £10.00          |
-| eur     | Adds the `€` symbol to your number value                                            | 10         | €10.00          |
-| jpy     | Adds the `¥` symbol to your number value                                            | 10         | ¥10             |
-| percent | Adds the `%` symbol and multiplies your value by 100                                | 0.1        | %10             |
-| id      | Removes commas and spaces from number or string types so that they appear like IDs. | 12,389,572 | 12389572        |

--- a/docs/references/metrics.mdx
+++ b/docs/references/metrics.mdx
@@ -95,7 +95,7 @@ models:
               sql: 'IF(${revenue} IS NULL, 10, ${revenue})'
               groups: ['product_details', 'item_details'] # this would add the metric to a nested group: `product details` --> `item details`
               hidden: false
-              format: '"£"#,##0.00' # GBP rounded to two decimal points
+              format: '[£]#,##0.00' # GBP rounded to two decimal points
               show_underlying_values:
                 - revenue
                 - forecast_date
@@ -113,7 +113,7 @@ Here are all of the properties you can customize:
 | [description](#description)                         | No       | string                         | Description of the metric that appears in Lightdash. A default description is created by Lightdash if this isn't included                                                                                                                            |
 | [sql](#custom-sql-in-aggregate-metrics)             | No       | string                         | Custom SQL used to define the metric.                                                                                                                                                                                                                |
 | hidden                                              | No       | boolean                        | If set to `true`, the metric is hidden from Lightdash. By default, this is set to `false` if you don't include this property.                                                                                                                        |
-| [format](#format)                                   | No       | string                         | This option will format the output value on the results table and CSV export. Currently supports one of the following: `['km', 'mi', 'usd', 'gbp', 'eur', 'percent', 'id']`                                                                           |
+| [format](#format)                                   | No       | string                         | This option will format the output value on the results table and CSV export. Supports spreadsheet-style formatting (e.g. #,##0.00). Use [this website](https://customformats.com/) to help build your custom format.                                                                           |
 | [groups](#groups)                                   | No       | string or string[]             | If you set this property, the metric will be grouped in the sidebar with other metrics with the same group label.                                                                                                                                    |
 | [urls](./dimensions.mdx#urls)                       | No       | Array of { url, label }        | Adding urls to a metric allows your users to click metric values in the UI and take actions, like opening an external tool with a url, or open at a website. You can use liquid templates to customise the link based on the value of the dimension. |
 | [show_underlying_values](#show-underlying-values)   | No       | Array of dimension names       | You can limit which dimensions are shown for a field when a user clicks `View underlying data`. The list must only include dimension names from the base model or from any joined models.                                                            |
@@ -428,16 +428,16 @@ models:
 
 These are the options:
 
-| Option  | Description                                                                         | Raw value  | Displayed value |
-| ------- | ----------------------------------------------------------------------------------- | ---------- | --------------- |
-| km      | Adds the suffix `km` to your value                                                  | 10         | 10 km           |
-| mi      | Adds the suffix `mile` to your value                                                | 10         | 10 mi           |
-| usd     | Adds the `$` symbol to your number value                                            | 10         | $10.00          |
-| gbp     | Adds the `£` symbol to your number value                                            | 10         | £10.00          |
-| eur     | Adds the `€` symbol to your number value                                            | 10         | €10.00          |
-| jpy     | Adds the `¥` symbol to your number value                                            | 10         | ¥10             |
-| percent | Adds the `%` symbol and multiplies your value by 100                                | 0.1        | %10             |
-| id      | Removes commas and spaces from number or string types so that they appear like IDs. | 12,389,572 | 12389572        |
+| Option  | Equivalent format expression   | Description                                                                         | Raw value  | Displayed value |
+| ------- | ------------------------------ | ----------------------------------------------------------------------------------- | ---------- | --------------- |
+| km      | '#,##0.00" km"'                | Adds the suffix `km` to your value                                                  | 10         | 10 km           |
+| mi      | '#,##0.00" mi"'                | Adds the suffix `mile` to your value                                                | 10         | 10 mi           |
+| usd     | '[$]#,##0.00'                  | Adds the `$` symbol to your number value                                            | 10         | $10.00          |
+| gbp     | '[£]#,##0.00'                  | Adds the `£` symbol to your number value                                            | 10         | £10.00          |
+| eur     | '[€]#,##0.00'                  | Adds the `€` symbol to your number value                                            | 10         | €10.00          |
+| jpy     | '[¥]#,##0.00'                  | Adds the `¥` symbol to your number value                                            | 10         | ¥10             |
+| percent | '#,##0.00%'                    | Adds the `%` symbol and multiplies your value by 100                                | 0.1        | %10             |
+| id      | No custom format expression    | Removes commas and spaces from number or string types so that they appear like IDs. | 12,389,572 | 12389572        |
 
 #### Compact (legacy)
 
@@ -456,12 +456,12 @@ You can compact values in your YAML. For example, if I wanted all of my revenue 
 	            compact: thousands # You can also use 'K'
 ```
 
-| Value     | Alias              | Example output |
-| --------- | ------------------ | -------------- |
-| thousands | "K" and "thousand" | 1K             |
-| millions  | "M" and "million"  | 1M             |
-| billions  | "B" and "billion"  | 1B             |
-| trillions | "T" and "trillion" | 1T             |
+| Value     | Alias              | Equivalent format expression            | Example output |
+| --------- | ------------------ | --------------------------------------- | -------------- |
+| thousands | "K" and "thousand" | '$#,##0," K"' or '$#,##0.00," K"'       | 1K             |
+| millions  | "M" and "million"  | '$#,##0,," M"' or '$#,##0.00,," M"'     | 1M             |
+| billions  | "B" and "billion"  | '$#,##0,,," B"' or '$#,##0.00,,," B"'   | 1B             |
+| trillions | "T" and "trillion" | '$#,##0,,,," T"' or '$#,##0.00,,,," T"' | 1T             |
 
 #### Round (legacy)
 
@@ -477,7 +477,7 @@ You can round values to appear with a certain number of decimal points.
           metrics:
             total_revenue:
               type: sum
-              round: 0
+              round: 0 # equivalent format expression: '#,##0.0'
 ```
 
 </details>

--- a/docs/references/metrics.mdx
+++ b/docs/references/metrics.mdx
@@ -95,7 +95,7 @@ models:
               sql: 'IF(${revenue} IS NULL, 10, ${revenue})'
               groups: ['product_details', 'item_details'] # this would add the metric to a nested group: `product details` --> `item details`
               hidden: false
-              format: '[£]#,##0.00' # GBP rounded to two decimal points
+              format: '[$£]#,##0.00' # GBP rounded to two decimal points
               show_underlying_values:
                 - revenue
                 - forecast_date
@@ -446,9 +446,9 @@ These are the options:
 | km      | '#,##0.00" km"'                | Adds the suffix `km` to your value                                                  | 10         | 10 km           |
 | mi      | '#,##0.00" mi"'                | Adds the suffix `mile` to your value                                                | 10         | 10 mi           |
 | usd     | '[$]#,##0.00'                  | Adds the `$` symbol to your number value                                            | 10         | $10.00          |
-| gbp     | '[£]#,##0.00'                  | Adds the `£` symbol to your number value                                            | 10         | £10.00          |
-| eur     | '[€]#,##0.00'                  | Adds the `€` symbol to your number value                                            | 10         | €10.00          |
-| jpy     | '[¥]#,##0.00'                  | Adds the `¥` symbol to your number value                                            | 10         | ¥10             |
+| gbp     | '[$£]#,##0.00'                 | Adds the `£` symbol to your number value                                            | 10         | £10.00          |
+| eur     | '[$€]#,##0.00'                 | Adds the `€` symbol to your number value                                            | 10         | €10.00          |
+| jpy     | '[$¥]#,##0.00'                 | Adds the `¥` symbol to your number value                                            | 10         | ¥10             |
 | percent | '#,##0.00%'                    | Adds the `%` symbol and multiplies your value by 100                                | 0.1        | %10             |
 | id      | '0'                            | Removes commas and spaces from number or string types so that they appear like IDs. | 12389572   | 12389572        |
 


### PR DESCRIPTION
adds custom formatting options to docs and places old `format`, `compact`, and `round` docs into a `legacy` section

closes: https://github.com/lightdash/lightdash/issues/13637