### PR TITLE
fix: environment variable headings

### DIFF
--- a/docs/self-host/customize-deployment/environment-variables.mdx
+++ b/docs/self-host/customize-deployment/environment-variables.mdx
@@ -128,7 +128,7 @@ These variables enable you to control Single Sign On (SSO) functionality.
 | `LIGHTDASH_CSP_ALLOWED_DOMAINS` | List of domains that are allowed to load resources from. Values must be separated by commas.                       |           |         |
 | `LIGHTDASH_CSP_REPORT_URI`      | URI to send CSP violation reports to.                                                                              |           |         |
 
-### Analytics & Event Tracking
+## Analytics & Event Tracking
 
 | Variable                     | Description                                                                                        | Required? | Default |
 | ---------------------------- | -------------------------------------------------------------------------------------------------- | --------- | ------- |
@@ -138,7 +138,7 @@ These variables enable you to control Single Sign On (SSO) functionality.
 | `POSTHOG_FE_API_HOST`        | Hostname for Posthog’s front-end API                                                               |           |         |
 | `POSTHOG_BE_API_HOST`        | Hostname for Posthog’s back-end API                                                                |           |         |
 
-### AI Analyst
+## AI Analyst
 
 These variables enable you to configure the [AI Analyst functionality](guides/ai-analyst.mdx).
 
@@ -154,7 +154,7 @@ These variables enable you to configure the [AI Analyst functionality](guides/ai
 | `LANGCHAIN_API_KEY`                   | Required for AI Analyst        |           |         |
 | `LANGCHAIN_PROJECT`                   | Required for AI Analyst        |           |         |
 
-### Slack Integration
+## Slack Integration
 
 These variables enable you to configure the [Slack integration](guides/using-slack-integration.mdx).
 
@@ -165,7 +165,7 @@ These variables enable you to configure the [Slack integration](guides/using-sla
 | `SLACK_CLIENT_SECRET`  | Required for Slack integration  |               |         |
 | `SLACK_STATE_SECRET`   | Required for Slack integration  |               |         |
 
-### GitHub Integration
+## GitHub Integration
 
 These variables enable you to configure Github integrations
 


### PR DESCRIPTION
Amend heading to be at the same level as the rest.

Before:

<img width="228" alt="Screenshot 2025-02-26 at 16 33 10" src="https://github.com/user-attachments/assets/74411c7f-7cbb-4656-aa1d-35184f99edb8" />

After:
<img width="259" alt="Screenshot 2025-02-26 at 17 21 45" src="https://github.com/user-attachments/assets/806cc24c-b17d-4de7-b7f4-ac62b8568182" />
