### PR TITLE
docs: render markdown links correctly inside <details> blocks

### DIFF
--- a/docs/get-started/setup-lightdash/get-project-lightdash-ready.mdx
+++ b/docs/get-started/setup-lightdash/get-project-lightdash-ready.mdx
@@ -109,7 +109,7 @@ For example, if we have a `projects.yml` file, we'd have a Table called `Project
 
 <details>
   <summary>Generate Tables and dimensions for some of the models in my dbt project:</summary>
-  There may be a specific set of models that you want to start out with as Tables in Lightdash. If this is the case, we recommend [using dbt's `tags`](https://docs.getdbt.com/reference/resource-configs/tags) to tag these models. You can use sets of existing tags, or you can create a new Lightdash-specific tag. Something like this:
+  There may be a specific set of models that you want to start out with as Tables in Lightdash. If this is the case, we recommend <a href="https://docs.getdbt.com/reference/resource-configs/tags">using dbt's <code>tags</code></a> to tag these models. You can use sets of existing tags, or you can create a new Lightdash-specific tag. Something like this:
 
 ```yaml
 {{


### PR DESCRIPTION
### Closes: #65 
Markdown links inside `<details>` were not rendering correctly because there was no newline after `<summary>`. While adding a newline could fix this, it's fragile since it can be easily refactored out by mistake.  

### Fix  
Replaced the Markdown-style link:  
```markdown
[using dbt's `tags`](https://docs.getdbt.com/reference/resource-configs/tags)
```
with an HTML `<a>` tag:  
```html
<a href="https://docs.getdbt.com/reference/resource-configs/tags">using dbt's <code>tags</code></a>
```
This ensures the link renders correctly across while keeping the `<details>` formatting intact.  

### Why This Approach?  
- A newline after `<summary>` is unreliable and can break if refactored  
- The HTML `<a>` tag ensures consistent rendering  
- Maintains readability and proper formatting inside `<details>`  

### Screenshots
**Before**
![image](https://github.com/user-attachments/assets/3a7166c4-323d-44eb-a506-5a3c24fa0ef8)

**Now**
![image](https://github.com/user-attachments/assets/92b04813-c87c-4c30-8199-658f31958cb9)
