### PR TITLE
docs: update gitHub references to new docs repo

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -11,7 +11,7 @@ module.exports = {
     onBrokenMarkdownLinks: 'warn',
     favicon: 'img/favicon-32x32.png', // TODO update
     organizationName: 'lightdash', // Usually your GitHub org/user name.
-    projectName: 'lightdash', // Usually your repo name.
+    projectName: 'lightdash-docs',
     plugins: [
         [
             path.resolve(__dirname, 'docusaurus-rudderstack-plugin'),
@@ -102,7 +102,7 @@ module.exports = {
                     position: 'left',
                 },
                 {
-                    href: 'https://github.com/lightdash/lightdash',
+                    href: 'https://github.com/lightdash/lightdash-docs',
                     position: 'right',
                     className: 'header-github-link',
                     'aria-label': 'GitHub repository',
@@ -120,7 +120,7 @@ module.exports = {
             links: [
                 {
                     label: 'Community',
-                    href: 'https://github.com/lightdash/lightdash/discussions',
+                    href: 'https://github.com/lightdash/lightdash-docs/discussions',
                 },
                 {
                     label: 'Blog',
@@ -149,9 +149,8 @@ module.exports = {
                 docs: {
                     sidebarPath: require.resolve('./sidebars.js'),
                     routeBasePath: '/',
-                    // Please change this to your repo.
                     editUrl:
-                        'https://github.com/lightdash/lightdash/edit/main/docs/',
+                        'https://github.com/lightdash/lightdash-docs/edit/main/',
                 },
                 theme: {
                     customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
### Fix outdated GitHub links in documentation
Closes #35 

#### Summary  
This PR updates all GitHub references in the documentation to point to the new repository (`lightdash-docs`). The "Edit this page" link was also fixed by removing the unnecessary `/docs` suffix from `editUrl`.

#### Issue  
Currently, links to GitHub in the documentation still reference `https://github.com/lightdash/lightdash`, including the "Edit this page" button at the bottom of docs pages. This is incorrect since the documentation now lives in `https://github.com/lightdash/lightdash-docs`.

#### Solution  
- Updated all references to `https://github.com/lightdash/lightdash-docs`.  
- Fixed `editUrl` in `docusaurus.config.js` by removing `/docs`, ensuring correct redirection.  

#### Testing  
- Clicking the "Edit this page" button should now open the correct file in the `lightdash-docs` repository.  
- Other GitHub links in the documentation should point to the new repository.  